### PR TITLE
Refactor Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
 # hm-prowee
-Communicate with Homegear server over XML-RPC
+
+Communicate with Homegear server over XML-RPC. This script was designed to be able to set the temperature config of a "HM-CC-RT-DN"-Devide.
 
 ## Usage
 
-    hm-prowee -u <user> -s <server> -p <port> list
-    hm-prowee -u <user> -s <server> -p <port> print-config <id>
-    hm-prowee -u <user> -s <server> -p <port> set-temp <id> <file>
+    usage: hm-prowee.py [-h] [-s SERVER] [-u USER] [-p PORT] [-P PASSWORD] [-c CONFIG]
+                        {list,print-config,print-temp,set-temp} ...
+    
+    Communicate with homegear.
+    
+    positional arguments:
+      {list,print-config,print-temp,set-temp}
+        list                Print list of devices
+        print-config        Print current config
+        print-temp          Print current temperature configuration
+        set-temp            Set Device Temperature Configuration
+    
+    optional arguments:
+      -h, --help            show this help message and exit
+      -s SERVER, --server SERVER
+                            server to use
+      -u USER, --user USER  user
+      -p PORT, --port PORT  xmlrpc port
+      -P PASSWORD, --password PASSWORD
+                            password for server/user, if empty or not set in the configuration, ask user
+      -c CONFIG, --config CONFIG
+                            configuration file instead of default config
 
-* `<user>` is the user created in homegear to connect to, follow the [homegear documentation on user management](https://www.homegear.eu/index.php/Create_or_Delete_Users_Using_Homegear%27s_Command_Line_Interface)
-* the password for the connection will be prompted after execution of the program
-* `<server>` specifies the address of your homegear server as hostname or IP (`homegearpi.local`, `localhost` or `192.168.1.1`), not in URL Syntax (like "http://example.com")
-* `<port>` is the RPC server port
+* `USER` is the user created in homegear to connect to, follow the [homegear documentation on user management](https://www.homegear.eu/index.php/Create_or_Delete_Users_Using_Homegear%27s_Command_Line_Interface)
+* the password for the connection will be prompted after execution of the program, if not set as parameter or inside  the config
+* `SERVER` specifies the address of your homegear server as hostname or IP (`homegearpi.local`, `localhost` or `192.168.1.1`), not in URL Syntax (like "http://example.com")
+* `PORT` is the RPC server port
+* `CONFIG` is the config file to be read. If not set, the default config file is `$HOME/.config/hm-prowee/config`.
+
+The command line parameter take precedence over the values in the config file. For configuration options see section [Configuration File](#configuration-file)
 
 There are two default ports to use with homegear (0.60). Connnections are SSL encrypted on both `2002` and `2003`. **Attention:** Only the later actually verifies the provided username and password. For further details check and edit `/etc/homegear/rpcservers.conf`.
 
@@ -21,6 +44,20 @@ The `print-config` will print the actual config of the `<id>`.
 The `print-temp` command will print the current temperature data of the device with `id` and may act as a starting point to get the current schedule as a temperature file.
 
 The `set-temp` command will then set the device with the `id` the temperature config from the `file`. For the syntax of the file see below.
+
+## Configuration File
+
+The configuration file location is `$HOME/.config/hm-prowee/config`. Example config:
+
+    [main]
+    server = 192.168.1.234
+    port = 2002
+    user = homegearuser
+    password = homegear
+
+The section `main` can contain `server`, `port`, `user` and `password`.
+Command line arguments take precedence over the config file.
+The `password` key can be skipped. If not present or not specified in the command line, the password is asked.
 
 ## Syntax of the Temperature file
 

--- a/hm-prowee.py
+++ b/hm-prowee.py
@@ -2,23 +2,21 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 #
-# Copyright © 2016 Christoph Heuel <mail@christoph-heuel.net>
+# Copyright © 2016-2021 Christoph Heuel <christoph@heuel-web.de>
 # Distributed under terms of the MIT license.
 #
 """
-Usage:
-    hm-prowee -u <user> -s <server> -p <port> list
-    hm-prowee -u <user> -s <server> -p <port> print-config <id>
-    hm-prowee -u <user> -s <server> -p <port> print-temp <id>
-    hm-prowee -u <user> -s <server> -p <port> set-temp <id> <file>
+Manage Homgear Heater Devices
 """
 import xmlrpc.client
 import ssl
 import json
-from docopt import docopt
 import getpass
+import argparse
+import configparser
+import os
+import sys
 
-xmlc = None
 
 MAX_POINTS = 13
 MAX_ENDTIME = 1440
@@ -27,70 +25,81 @@ MAX_ENDTIME = 1440
 HG_FILTER_BY_TYPE_ID = 3
 HG_HEATERS_TYPE_ID = "0x95"
 
+
+class ConfigError(Exception):
+    pass
+
+
 def pp(jsontext):
     """Pretty print json text"""
-    print(json.dumps(jsontext, sort_keys=True, indent=4, separators=(',', ': ')))
+    print(json.dumps(jsontext, sort_keys=True, indent=4,
+                     separators=(',', ': ')))
 
-def list_heaters():
+
+def list_heaters(xmlc, args):
     """List heater devices from server"""
     try:
         heaters = xmlc.getPeerId(HG_FILTER_BY_TYPE_ID, HG_HEATERS_TYPE_ID)
-    except:
+    except Exception:
         print("Can't load list of devices!")
         exit(1)
-    print("{0:4} {1}".format("ID", "Name"));
+    print("{0:4} {1}".format("ID", "Name"))
     for i in heaters:
         print("{0:4} {1}".format(i, xmlc.getName(i)))
 
-def print_paramsets(id):
-    """Print parameterset for specific device id
 
-    :param id: device ID to receive Parameterset for"""
-    pp(xmlc.getParamset(int(id), 0, "MASTER"))
-    
-def print_temp_config(id):
-    """Print temp config file for specific device id
+def print_paramsets(xmlc, args):
+    """Print parameterset for specific device id"""
+    pp(xmlc.getParamset(int(args.id), 0, "MASTER"))
 
-    :param id: device ID to receive temp config for"""
-    params = xmlc.getParamset(int(id), 0, "MASTER")
-    weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+
+def print_temp_config(xmlc, args):
+    """Print temp config file for specific device id"""
+    params = xmlc.getParamset(int(args.id), 0, "MASTER")
+    weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday",
+                "saturday", "sunday"]
 
     for weekday in weekdays:
         elements = []
-        
+
         for i in range(1, MAX_POINTS+1):
             temperature_key = "TEMPERATURE_{0}_{1}".format(weekday.upper(), i)
             endtime_key = "ENDTIME_{0}_{1}".format(weekday.upper(), i)
-            
+
             temperature_value = params[temperature_key]
             endtime_value = params[endtime_key]
-            
-            elements.append("{0:.1f} > {1};".format(temperature_value, calculate_timedef_from_minutes(endtime_value)))
-            
+
+            elements.append("{0:.1f} > {1};".format(
+                temperature_value,
+                calculate_timedef_from_minutes(endtime_value)))
+
             if endtime_value == MAX_ENDTIME:
                 break
-        
-        print("{0} = {1}".format(weekday.upper(), " ".join(elements))) 
+
+        print("{0} = {1}".format(weekday.upper(), " ".join(elements)))
+
 
 def calculate_minutes_from_midnight(timedef):
     """Calculate from time the minites from midnight
 
     :param timedef: Time to calculate minutes from midnight. Eg. '07:00'
     :returns: Minutes from midnight"""
-    l = timedef.split(":")
-    if not len(l) == 2:
+    hour_minutes = timedef.split(":")
+    if not len(hour_minutes) == 2:
         raise TypeError("{0} is not in format HH:MM!".format(timedef))
-    hours = int(l[0])
-    minutes = hours*60 + int(l[1])
+    hours = int(hour_minutes[0])
+    minutes = hours*60 + int(hour_minutes[1])
     if minutes > MAX_ENDTIME:
         minutes = MAX_ENDTIME
     return minutes
-    
+
+
 def calculate_timedef_from_minutes(minutes):
     """Calculate time from minutes from midnight
 
     :param timedef: Minutes from midnight for calculation"""
     return "{0:02}:{1:02}".format(int(minutes / 60), minutes % 60)
+
 
 def parse_temperature_item(item):
     """Parse item for time and temperature
@@ -99,8 +108,11 @@ def parse_temperature_item(item):
     :returns: dict with temperature and minutes"""
     temp_time_tupel = item.split(">")
     temperature = float(temp_time_tupel[0].strip())
-    minutes_from_midnight = calculate_minutes_from_midnight(temp_time_tupel[1].strip())
-    return { 'minutes_from_midnight' : minutes_from_midnight, 'temperature' : temperature}
+    minutes_from_midnight = calculate_minutes_from_midnight(
+        temp_time_tupel[1].strip())
+    return {'minutes_from_midnight': minutes_from_midnight,
+            'temperature': temperature}
+
 
 def parse_temperature_definition(temp_def_raw):
     """Parse list of temperature definitions
@@ -108,10 +120,11 @@ def parse_temperature_definition(temp_def_raw):
     :param temp_def_raw: List separated by ';' of temperature/time definitions
     :returns: list of hashes with temperature/time definitions"""
     temp_def_list = filter(None, temp_def_raw.split(";"))
-    l = []
+    temp_array = []
     for i in temp_def_list:
-        l.append(parse_temperature_item(i))
-    return l
+        temp_array.append(parse_temperature_item(i))
+    return temp_array
+
 
 def read_from_file(filename):
     """Read config file
@@ -125,16 +138,16 @@ def read_from_file(filename):
     deflist = {}
     for i in lines:
         if i.startswith("#"):
-            print("Comment Line, ignoring")
             continue
-        l = i.split("=")
-        weekday = l[0].strip()
-        temp_def = parse_temperature_definition(l[1])
+        line_array = i.split("=")
+        weekday = line_array[0].strip()
+        temp_def = parse_temperature_definition(line_array[1])
         deflist[weekday] = temp_def
 
     return deflist
 
-def set_temp_to_homegear(id, definition_list):
+
+def set_temp_to_homegear(xmlc, id, definition_list):
     """Send list of definitions to ID
 
     :param id: ID to receive definition
@@ -160,39 +173,109 @@ def set_temp_to_homegear(id, definition_list):
     print(send_dict)
     xmlc.putParamset(int(id), 0, "MASTER", send_dict)
 
-def set_temp_config(id, template_file):
+
+def set_temp_config(xmlc, args):
     """Read file and send to server
 
     :param id: ID to receive values
     :param template_file: File to read from"""
-    config_from_file = read_from_file(template_file)
-    set_temp_to_homegear(id, config_from_file)
+    config_from_file = read_from_file(args.file)
+    set_temp_to_homegear(xmlc, args.id, config_from_file)
 
-if __name__ == "__main__":
-    arguments = docopt(__doc__)
+
+def _map_cli_config(mapping, args, ini):
+    res_config = {}
+    for i in mapping:
+        if i in args and args[i]:
+            res_config[i] = args[i]
+        elif ini and i in ini:
+            res_config[i] = ini[i]
+        else:
+            raise ConfigError(f"Config/Argument for {i} set!")
+    return res_config
+
+
+def get_config_and_args():
+    parser = argparse.ArgumentParser(description='Communicate with homegear.')
+    parser.add_argument("-s", "--server", help="server to use")
+    parser.add_argument("-u", "--user", help="user")
+    parser.add_argument("-p", "--port", help="xmlrpc port")
+    parser.add_argument("-P", "--password", help="password for server/user, if"
+                        " empty or not set in the configuration, ask user")
+    parser.add_argument("-c", "--config", help="configuration file instead of "
+                        "default config")
+    subparsers = parser.add_subparsers()
+
+    list_p = subparsers.add_parser("list", help="Print list of devices")
+    list_p.set_defaults(func=list_heaters)
+
+    cconfig_p = subparsers.add_parser("print-config",
+                                      help="Print current config")
+    cconfig_p.add_argument("id")
+    cconfig_p.set_defaults(func=print_paramsets)
+
+    ptemp_c = subparsers.add_parser(
+        "print-temp", help="Print current temperature configuration")
+    ptemp_c.add_argument("id")
+    ptemp_c.set_defaults(func=print_temp_config)
+
+    settemp_p = subparsers.add_parser(
+        "set-temp", help="Set Device Temperature Configuration")
+    settemp_p.add_argument("id")
+    settemp_p.add_argument("file")
+    settemp_p.set_defaults(func=set_temp_config)
+
+    args = parser.parse_args()
+
+    if "func" not in args:
+        print("No Command given", file=sys.stderr)
+        parser.print_usage()
+        exit(1)
+
+    ini_config = configparser.ConfigParser()
+    if args.config:
+        ini_config.read(args.config)
+    else:
+        ini_config.read(os.path.expanduser("~/.config/hm-prowee/config"))
+
+    sec_config = ini_config["main"] if "main" in ini_config else None
+
+    try:
+        res_config = _map_cli_config(["server", "user", "port"],
+                                     vars(args), sec_config)
+    except ConfigError as e:
+        print(e, file=sys.stderr)
+        exit(1)
+
+    if args.password:
+        res_config["password"] = args.password
+    elif sec_config and "password" in sec_config:
+        res_config["password"] = sec_config["password"]
+    else:
+        res_config["password"] = getpass.getpass()
+
+    return (res_config, args)
+
+
+def main():
+    (cfg, args) = get_config_and_args()
+
     ctx = ssl._create_unverified_context()
 
-    passwd = getpass.getpass()
-
-    xmlc = xmlrpc.client.ServerProxy(
-        "https://{0}:{1}@{2}:{3}/".format(
-            arguments['<user>'], passwd, arguments['<server>'], arguments['<port>']
-        ),
-    context=ctx)
+    xmlc = xmlrpc.client.ServerProxy(f"https://{cfg['user']}:{cfg['password']}"
+                                     f"@{cfg['server']}:{cfg['port']}/",
+                                     context=ctx)
 
     try:
         version = xmlc.getVersion()
-        print("Successfully connected to", version)
-    except:
-        print ("Connection not successful, please check your parameters.")
+        print(f"Successfully connected to server {cfg['server']}"
+              f", running version {version}", file=sys.stderr)
+    except Exception:
+        print("Connection not successful, please check your parameters.")
         exit(1)
 
-    if arguments['list']:
-        list_heaters()
-    elif arguments['print-config']:
-        print_paramsets(arguments["<id>"])
-    elif arguments['print-temp']:
-        print_temp_config(arguments["<id>"])
-    elif arguments['set-temp']:
-        set_temp_config(arguments["<id>"], arguments["<file>"])
+    args.func(xmlc, args)
 
+
+if __name__ == "__main__":
+    main()

--- a/hm-prowee.py
+++ b/hm-prowee.py
@@ -270,8 +270,8 @@ def main():
         version = xmlc.getVersion()
         print(f"Successfully connected to server {cfg['server']}"
               f", running version {version}", file=sys.stderr)
-    except Exception:
-        print("Connection not successful, please check your parameters.")
+    except Exception as e:
+        print("Connection not successful, please check your parameters.", e)
         exit(1)
 
     args.func(xmlc, args)


### PR DESCRIPTION
* Remove docopt dependency, use Python 3 standard libraries
* Introduce config file, to make the CLI cleaner (server, port, user,
  password)
* Try to keep the changes backwards compatible, former CLI access should
  be the same
* The password can be stored in config, given by CLI or it is asked to
  enter
* The default config resides in `~/.config/hm-prowee/config`. The
  content should be set like something:

```
[main]
server = homegearserver
port = 2002
user = homegear
password = mypassword
```

* Informative and Error Output is now redirected to stderr. So
  redirecting the config output (`hm-prowee.py print-temp <id>`) does
  not contain the informational output.
* Cosmetic changes are done so that PEP8 is respected.
* Closes #8